### PR TITLE
RALPH: Replace cloudscraper with requests.Session and fix retry logic…

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -33,5 +33,5 @@ CREATE_REVERSE = False
 CREATE_CLOZE = False
 
 # Rate limiting (prevents HTTP 429 errors when mass-scraping)
-REQUEST_DELAY = 2  # Seconds between requests (reduced with session caching)
+REQUEST_DELAY = 1  # Seconds between requests (reduced with session caching)
 MAX_RETRIES = 3  # Retry attempts for HTTP 429 errors

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ requests==2.31.0
 beautifulsoup4==4.12.3
 anki==2.1.65
 colorama==0.4.6
-cloudscraper==1.2.71

--- a/scraper/adjective_scraper.py
+++ b/scraper/adjective_scraper.py
@@ -7,12 +7,7 @@ from scraper_utils import fetch_with_retry
 def extract_adjective_data(word, config):
     """Main function to extract adjective data from verben.de"""
     url = f"{config.BASE_URL}/deklination/adjektive/steckbrief/info/{word}.htm"
-    headers = {
-        "Accept-Language": config.LANGUAGE,
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    }
-    
-    response, error = fetch_with_retry(url, headers, config)
+    response, error = fetch_with_retry(url, config)
     if error:
         print(f"Error for '{word}': {error}")
         return None

--- a/scraper/adverb_scraper.py
+++ b/scraper/adverb_scraper.py
@@ -6,12 +6,7 @@ from scraper_utils import fetch_with_retry
 def extract_adverb_data(word, config):
     """Main function to extract adverb data from verben.de"""
     url = f"{config.ALT_BASE_URL}/adverbien/steckbrief-info/{word}.htm"
-    headers = {
-        "Accept-Language": config.LANGUAGE,
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    }
-    
-    response, error = fetch_with_retry(url, headers, config)
+    response, error = fetch_with_retry(url, config)
     if error:
         print(f"Error for '{word}': {error}")
         return None

--- a/scraper/noun_scraper.py
+++ b/scraper/noun_scraper.py
@@ -7,12 +7,7 @@ from scraper_utils import fetch_with_retry
 def extract_noun_data(word, config):
     """Main function to extract noun data from verbformen.de"""
     url = f"{config.BASE_URL}/deklination/substantive/steckbrief/info/{word}.htm"
-    headers = {
-        "Accept-Language": config.LANGUAGE,
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    }
-    
-    response, error = fetch_with_retry(url, headers, config)
+    response, error = fetch_with_retry(url, config)
     if error:
         print(f"Error for '{word}': {error}")
         return None

--- a/scraper/scraper_utils.py
+++ b/scraper/scraper_utils.py
@@ -1,51 +1,46 @@
 import time
 import random
-import cloudscraper
+import requests
 from urllib.parse import urlparse
 
 
-# Session cache to reuse cloudscraper sessions across requests
-# This avoids solving Cloudflare challenges repeatedly
+# Session cache to reuse requests sessions across requests
+# This preserves cookies and TCP connections for better performance
 _session_cache = {}
 
 
 def get_scraper_for_domain(domain):
     """
-    Get or create a cloudscraper session for a specific domain.
-    Sessions are cached to preserve cookies and avoid re-solving challenges.
+    Get or create a requests Session for a specific domain.
+    Sessions are cached to preserve cookies and TCP connections.
     """
     if domain not in _session_cache:
-        _session_cache[domain] = cloudscraper.create_scraper(
-            browser='chrome',
-            delay=10,  # Delay for Cloudflare challenge solving (first request only)
-        )
+        _session_cache[domain] = requests.Session()
     return _session_cache[domain]
 
 
-def fetch_with_retry(url, headers, config, max_retries=3, base_delay=2):
+def fetch_with_retry(url, config, max_retries=3):
     """
-    Fetch URL with rate limiting and Cloudflare bypass using cloudscraper.
+    Fetch URL with rate limiting and retry logic using requests.Session.
 
     Args:
         url: The URL to fetch
-        headers: HTTP headers for the request
         config: Configuration object with REQUEST_DELAY attribute
         max_retries: Maximum number of retry attempts (default: 3)
-        base_delay: Base delay in seconds (default: 2)
 
     Returns:
         Tuple of (response, error_message):
         - On success: (response, None)
         - On failure: (None, error_message)
     """
-    delay = getattr(config, 'REQUEST_DELAY', base_delay)
+    delay = getattr(config, 'REQUEST_DELAY', 1)
 
     # Extract domain for session caching
     parsed_url = urlparse(url)
     domain = parsed_url.netloc
 
     # Get or create a cached session for this domain
-    scraper = get_scraper_for_domain(domain)
+    session = get_scraper_for_domain(domain)
 
     for attempt in range(max_retries):
         try:
@@ -53,26 +48,36 @@ def fetch_with_retry(url, headers, config, max_retries=3, base_delay=2):
             jitter = random.uniform(0.8, 1.2)
             sleep_time = delay * jitter
 
+            # Apply exponential backoff on retries
             if attempt > 0:
                 sleep_time = delay * (2 ** attempt) * jitter
                 print(f"Rate limited. Waiting {sleep_time:.1f}s before retry...")
-            else:
-                time.sleep(sleep_time)
 
-            response = scraper.get(url, headers=headers, timeout=10)
+            # Sleep before every request (including retries)
+            time.sleep(sleep_time)
+
+            response = session.get(url, timeout=10)
 
             if response.status_code == 200:
                 return response, None
 
-            if response.status_code == 429:
+            # Retry on rate limit (429) and server errors (500-525)
+            if response.status_code == 429 or 500 <= response.status_code <= 525:
                 if attempt < max_retries - 1:
                     continue
                 else:
-                    return None, (
-                        f"HTTP 429: Rate limited. Try increasing REQUEST_DELAY in config.py "
-                        f"or wait a while before trying again."
-                    )
+                    if response.status_code == 429:
+                        return None, (
+                            f"HTTP 429: Rate limited. Try increasing REQUEST_DELAY in config.py "
+                            f"or wait a while before trying again."
+                        )
+                    else:
+                        return None, (
+                            f"HTTP {response.status_code}: Server error after {max_retries} retries. "
+                            f"Please try again later."
+                        )
 
+            # Client errors (4xx except 429) are not retried
             return None, f"HTTP {response.status_code}: Could not access page"
 
         except Exception as e:

--- a/scraper/verb_scraper.py
+++ b/scraper/verb_scraper.py
@@ -1,4 +1,4 @@
-import cloudscraper
+import requests
 from bs4 import BeautifulSoup
 import os
 from scraper_utils import fetch_with_retry
@@ -10,9 +10,15 @@ def download_audio(url, filename, media_path, base_url):
 
     audio_path = os.path.join(media_path, filename)
 
-    # Use cloudscraper for audio downloads too
-    scraper = cloudscraper.create_scraper(browser='chrome')
-    audio_data = scraper.get(url)
+    # Use requests.Session for audio downloads
+    import requests
+    from urllib.parse import urlparse
+    from scraper.scraper_utils import get_scraper_for_domain
+
+    parsed_url = urlparse(url)
+    domain = parsed_url.netloc
+    session = get_scraper_for_domain(domain)
+    audio_data = session.get(url)
 
     with open(audio_path, "wb") as f:
         f.write(audio_data.content)
@@ -22,12 +28,7 @@ def download_audio(url, filename, media_path, base_url):
 def extract_verb_data(word, config):
     """Main function to extract verb data from verbformen.de"""
     url = f"{config.BASE_URL}/konjugation/steckbrief/info/{word}.htm"
-    headers = {
-        "Accept-Language": config.LANGUAGE,
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-    }
-    
-    response, error = fetch_with_retry(url, headers, config)
+    response, error = fetch_with_retry(url, config)
     if error:
         print(f"Error for '{word}': {error}")
         return None


### PR DESCRIPTION
… (issue #8, PRD #7)

Completed all acceptance criteria:
- Replaced cloudscraper with requests.Session in scraper_utils.py
- Removed headers parameter from fetch_with_retry and all scraper calls
- Fixed sleep bug: time.sleep() now called before every retry attempt
- Added retry logic for 5xx status codes (500-525)
- Reduced REQUEST_DELAY from 2s to 1s in config.py
- Removed cloudscraper from requirements.txt
- Maintained per-domain session caching for TCP connection reuse

Key decisions made:
- Used exponential backoff (1s, 2s, 4s) with random jitter for retries
- 4xx (non-429) responses return error immediately without retry
- Clear rate-limit feedback printed when retries occur

Files changed:
- config/config.py: REQUEST_DELAY reduced from 2 to 1
- requirements.txt: removed cloudscraper==1.2.71
- scraper/scraper_utils.py: rewrote to use requests.Session
- scraper/verb_scraper.py: removed headers, updated download_audio
- scraper/noun_scraper.py: removed headers
- scraper/adjective_scraper.py: removed headers
- scraper/adverb_scraper.py: removed headers